### PR TITLE
fix formatting in mstdn.1.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ uninstall:
 man: doc/${NAME}.1.txt
 
 doc/${NAME}.1.txt: doc/${NAME}.1
-	mandoc -c -O width=80 $? | col -b >$@
+	mandoc -c -O width=80 $? | col -b -p | cat -v | \
+	sed 's/M-bM-^_M-(/</g' | sed 's/M-bM-^_M-)/>/g' | \
+	sed 's/M-BM-//g' | sed 's/M-bM-^@M-^S/-/g' >$@
 
 readme: man
 	sed -n -e '/^NAME/!p;//q' README.md >.readme

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please see the manual page for all details:
 
 ```
 NAME
-     mstdn  send a mastodon update
+     mstdn - send a mastodon update
 
 SYNOPSIS
      mstdn [-hiv] [-d descr] [-m media] [-s server] [-t file]
@@ -84,7 +84,7 @@ EXAMPLES
 	   mstdn -t ~/mytoken -s chaos.social -m file.jpg <msg
 
 EXIT STATUS
-     The mstdn utility exits0 on success, and>0 if an error occurs.
+     The mstdn utility exits 0 on success, and >0 if an error occurs.
 
 ENVIRONMENT
      The following environment variables affect the execution of this tool:
@@ -97,7 +97,7 @@ ENVIRONMENT
 		      defaults to the pathname ~/.mstdn/${MASTODON_SERVER}.
 
 HISTORY
-     mstdn was originally written by Jan Schaumann jschauma@netmeister.org in
+     mstdn was originally written by Jan Schaumann <jschauma@netmeister.org> in
      December 2022.
 
 BUGS

--- a/doc/mstdn.1.txt
+++ b/doc/mstdn.1.txt
@@ -1,7 +1,7 @@
 MSTDN(1)		     General Commands Manual			MSTDN(1)
 
 NAME
-     mstdn  send a mastodon update
+     mstdn - send a mastodon update
 
 SYNOPSIS
      mstdn [-hiv] [-d descr] [-m media] [-s server] [-t file]
@@ -54,7 +54,7 @@ EXAMPLES
 	   mstdn -t ~/mytoken -s chaos.social -m file.jpg <msg
 
 EXIT STATUS
-     The mstdn utility exits0 on success, and>0 if an error occurs.
+     The mstdn utility exits 0 on success, and >0 if an error occurs.
 
 ENVIRONMENT
      The following environment variables affect the execution of this tool:
@@ -67,7 +67,7 @@ ENVIRONMENT
 		      defaults to the pathname ~/.mstdn/${MASTODON_SERVER}.
 
 HISTORY
-     mstdn was originally written by Jan Schaumann jschauma@netmeister.org in
+     mstdn was originally written by Jan Schaumann <jschauma@netmeister.org> in
      December 2022.
 
 BUGS


### PR DESCRIPTION
On NetBSD 9.3, col filters out some meaningful control sequences produced by mandoc,
such as non-breaking spaces, and mail address marks.

This commit adds the `-p` flag of col to preserve those control sequences, then uses sed to replace them.

`mstdn.1.txt` is generated with the modified Makefile on NetBSD 9.3.